### PR TITLE
Change hardcoded year, use getFullYear from Date

### DIFF
--- a/src/pages/api/holidays.ts
+++ b/src/pages/api/holidays.ts
@@ -15,7 +15,12 @@ const handler = async (
   try {
     return res
       .status(200)
-      .json(getColombianHolidays(actualLang || 'es-CO', actualYear || 2021));
+      .json(
+        getColombianHolidays(
+          actualLang || 'es-CO',
+          actualYear || new Date().getFullYear(),
+        ),
+      );
   } catch (e: unknown) {
     return res.status(500).json({
       // @ts-ignore


### PR DESCRIPTION
I noticed that the home page (i.e. `/`) does an API request to `/api/holidays` only passing the `lang` query parameter. This behavior is working correctly because the Holidays API has `2021` as the default value for the year parameter, but there will be a problem in roughly two months when we move to 2022.

To prevent this error from happening in the future, I'm changing the hardcoded 2021 parameter instead of using the value returned by `Date.prototype.getFullYear`.